### PR TITLE
Anil/price feed tests

### DIFF
--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -15,9 +15,9 @@
     "@endo/far": "^1.1.5",
     "@endo/init": "^1.1.4",
     "ava": "^6.1.2",
+    "better-sqlite3": "11.5.0",
     "execa": "^9.3.1",
-    "tsx": "^4.17.0",
-    "better-sqlite3": "11.5.0"
+    "tsx": "^4.17.0"
   },
   "ava": {
     "concurrency": 1,

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -16,7 +16,8 @@
     "@endo/init": "^1.1.4",
     "ava": "^6.1.2",
     "execa": "^9.3.1",
-    "tsx": "^4.17.0"
+    "tsx": "^4.17.0",
+    "better-sqlite3": "11.5.0"
   },
   "ava": {
     "concurrency": 1,

--- a/a3p-integration/proposals/z:acceptance/priceFeed.test.js
+++ b/a3p-integration/proposals/z:acceptance/priceFeed.test.js
@@ -1,0 +1,78 @@
+import test from 'ava';
+import {
+  getTranscriptItemsForVat,
+  getVatsWithSameName,
+  swingStore,
+} from './test-lib/vat-helpers.js';
+import {
+  addPreexistingOracles,
+  generateOracleMap,
+  getPriceQuote,
+  GOV1ADDR,
+  GOV2ADDR,
+  GOV3ADDR,
+  pushPrices,
+  registerOraclesForBrand,
+  waitForBlock,
+} from '@agoric/synthetic-chain';
+import { bankSend, pollRoundIdAndPushPrice } from './test-lib/priceFeed-lib.js';
+
+const init = async oraclesByBrand => {
+  await registerOraclesForBrand('ATOM', oraclesByBrand);
+  await waitForBlock(3);
+  await registerOraclesForBrand('stATOM', oraclesByBrand);
+  await waitForBlock(3);
+
+  await pushPrices(1, 'ATOM', oraclesByBrand, 1);
+  await waitForBlock(3);
+  await pushPrices(1, 'stATOM', oraclesByBrand, 1);
+}
+
+/**
+ * @typedef {Map<string, Array<{ address: string; offerId: string }>>} OraclesByBrand
+ */
+
+test.before.skip(async t => {
+  // Fund each oracle members with 10IST incase we hit batch limit here https://github.com/Agoric/agoric-sdk/issues/6525
+  await bankSend(GOV2ADDR, '10000000uist', GOV1ADDR);
+  await bankSend(GOV3ADDR, '10000000uist', GOV1ADDR);
+
+  const oraclesByBrand = generateOracleMap('f-priceFeeds', ['ATOM', 'stATOM']);
+  t.log(oraclesByBrand);
+
+  await init(oraclesByBrand);
+  t.context = {
+    oraclesByBrand,
+  };
+});
+
+test.skip('push-price', async t => {
+  // @ts-expect-error casting
+  const { oraclesByBrand } = t.context;
+
+  await pollRoundIdAndPushPrice('ATOM', 25, oraclesByBrand);
+  await pollRoundIdAndPushPrice('stATOM', 21, oraclesByBrand);
+
+  const atomOut = await getPriceQuote('ATOM');
+  t.is(atomOut, '+25000000');
+  const stAtomOut = await getPriceQuote('stATOM');
+  t.is(stAtomOut, '+21000000');
+  t.pass();
+});
+
+test.serial('dum', async t => {
+  // const stATOM = await getVatsWithSameName('-stATOM-USD_price_feed');
+  // const scaledStATOM = await getVatsWithSameName(
+  //   '-scaledPriceAuthority-stATOM',
+  // );
+  // t.log(scaledStATOM);
+  const { findVatsAll, lookupVat, findVatsExact } = swingStore;
+
+  // const items = findVatsAll('scaledPriceAuthority');
+  // items.forEach(id => console.log(lookupVat(id).options(), id));
+
+  const stATOMScaledPAs = findVatsExact('-scaledPriceAuthority-stATOM');
+  stATOMScaledPAs.forEach(id => console.log(getTranscriptItemsForVat(id, 1).map((element) =>( JSON.parse(element.item).d[0]))));
+
+  t.pass();
+});

--- a/a3p-integration/proposals/z:acceptance/priceFeed.test.js
+++ b/a3p-integration/proposals/z:acceptance/priceFeed.test.js
@@ -1,11 +1,6 @@
 import test from 'ava';
+import '@endo/init';
 import {
-  getTranscriptItemsForVat,
-  getVatsWithSameName,
-  swingStore,
-} from './test-lib/vat-helpers.js';
-import {
-  addPreexistingOracles,
   generateOracleMap,
   getPriceQuote,
   GOV1ADDR,
@@ -15,8 +10,38 @@ import {
   registerOraclesForBrand,
   waitForBlock,
 } from '@agoric/synthetic-chain';
-import { bankSend, pollRoundIdAndPushPrice } from './test-lib/priceFeed-lib.js';
+import { snapshotVat } from './test-lib/vat-helpers.js';
+import {
+  bankSend,
+  ensureGCDeliveryOnly,
+  getQuoteFromVault,
+  pollRoundIdAndPushPrice,
+  scale6,
+} from './test-lib/priceFeed-lib.js';
 
+const config = {
+  vatNames: [
+    '-scaledPriceAuthority-stATOM',
+    '-scaledPriceAuthority-ATOM',
+    '-stATOM-USD_price_feed',
+    '-ATOM-USD_price_feed',
+  ],
+  snapshots: { before: {}, after: {} }, // Will be filled in the runtime
+  priceFeeds: {
+    ATOM: {
+      price: 29,
+      managerIndex: 0,
+      name: 'ATOM',
+    },
+    stATOM: {
+      price: 25,
+      managerIndex: 1,
+      name: 'stATOM',
+    },
+  },
+};
+
+// Remove this one when #10296 goes in
 const init = async oraclesByBrand => {
   await registerOraclesForBrand('ATOM', oraclesByBrand);
   await waitForBlock(3);
@@ -26,13 +51,13 @@ const init = async oraclesByBrand => {
   await pushPrices(1, 'ATOM', oraclesByBrand, 1);
   await waitForBlock(3);
   await pushPrices(1, 'stATOM', oraclesByBrand, 1);
-}
+};
 
 /**
  * @typedef {Map<string, Array<{ address: string; offerId: string }>>} OraclesByBrand
  */
 
-test.before.skip(async t => {
+test.before(async t => {
   // Fund each oracle members with 10IST incase we hit batch limit here https://github.com/Agoric/agoric-sdk/issues/6525
   await bankSend(GOV2ADDR, '10000000uist', GOV1ADDR);
   await bankSend(GOV3ADDR, '10000000uist', GOV1ADDR);
@@ -46,33 +71,53 @@ test.before.skip(async t => {
   };
 });
 
-test.skip('push-price', async t => {
-  // @ts-expect-error casting
-  const { oraclesByBrand } = t.context;
-
-  await pollRoundIdAndPushPrice('ATOM', 25, oraclesByBrand);
-  await pollRoundIdAndPushPrice('stATOM', 21, oraclesByBrand);
-
-  const atomOut = await getPriceQuote('ATOM');
-  t.is(atomOut, '+25000000');
-  const stAtomOut = await getPriceQuote('stATOM');
-  t.is(stAtomOut, '+21000000');
+test.serial('snapshot state', t => {
+  config.vatNames.forEach(name => {
+    config.snapshots.before[name] = snapshotVat(name);
+  });
+  console.dir(config.snapshots, { depth: null });
   t.pass();
 });
 
-test.serial('dum', async t => {
-  // const stATOM = await getVatsWithSameName('-stATOM-USD_price_feed');
-  // const scaledStATOM = await getVatsWithSameName(
-  //   '-scaledPriceAuthority-stATOM',
-  // );
-  // t.log(scaledStATOM);
-  const { findVatsAll, lookupVat, findVatsExact } = swingStore;
+test.serial('push-price', async t => {
+  // @ts-expect-error casting
+  const { oraclesByBrand } = t.context;
+  const {
+    priceFeeds: { ATOM, stATOM },
+  } = config;
 
-  // const items = findVatsAll('scaledPriceAuthority');
-  // items.forEach(id => console.log(lookupVat(id).options(), id));
+  await pollRoundIdAndPushPrice(ATOM.name, ATOM.price, oraclesByBrand);
+  await pollRoundIdAndPushPrice(stATOM.name, stATOM.price, oraclesByBrand);
 
-  const stATOMScaledPAs = findVatsExact('-scaledPriceAuthority-stATOM');
-  stATOMScaledPAs.forEach(id => console.log(getTranscriptItemsForVat(id, 1).map((element) =>( JSON.parse(element.item).d[0]))));
-
+  const atomOut = await getPriceQuote(ATOM.name);
+  t.is(atomOut, `+${scale6(ATOM.price)}`);
+  const stAtomOut = await getPriceQuote(stATOM.name);
+  t.is(stAtomOut, `+${scale6(stATOM.price)}`);
   t.pass();
+});
+
+test.serial('snapshot state after price pushed', t => {
+  config.vatNames.forEach(name => {
+    config.snapshots.after[name] = snapshotVat(name);
+  });
+  console.dir(config.snapshots, { depth: null });
+  t.pass();
+});
+
+test.serial('ensure only gc', t => {
+  ensureGCDeliveryOnly(config.snapshots);
+  t.pass();
+});
+
+test.serial('make sure vaults got the prices', async t => {
+  const {
+    priceFeeds: { ATOM, stATOM },
+  } = config;
+  const [atomVaultQuote, stAtomVaultQuote] = await Promise.all([
+    getQuoteFromVault(ATOM.managerIndex),
+    getQuoteFromVault(stATOM.managerIndex),
+  ]);
+
+  t.is(atomVaultQuote, scale6(ATOM.price).toString());
+  t.is(stAtomVaultQuote, scale6(stATOM.price).toString());
 });

--- a/a3p-integration/proposals/z:acceptance/priceFeed.test.js
+++ b/a3p-integration/proposals/z:acceptance/priceFeed.test.js
@@ -1,6 +1,20 @@
+/* eslint-env node */
+
+/**
+ * @file The purpose of this test is to make sure;
+ * - Old priceFeed and scaledPriceAuthority vats that are replaced with new ones are truly quiescent.
+ *   The method we use for this is to check if those vats received any deliveries from swingset that
+ *   are of type "message" or "notify" (We give delivery types related to GC a pass since GC cycles
+ *   aren't in our control).
+ * - Make sure new price feeds can produce quotes
+ * - Make sure vaults receive quotes
+ */
+
 import test from 'ava';
 import '@endo/init';
 import {
+  agd,
+  agoric,
   generateOracleMap,
   getPriceQuote,
   GOV1ADDR,
@@ -8,7 +22,6 @@ import {
   GOV3ADDR,
   pushPrices,
   registerOraclesForBrand,
-  waitForBlock,
 } from '@agoric/synthetic-chain';
 import { snapshotVat } from './test-lib/vat-helpers.js';
 import {
@@ -18,6 +31,16 @@ import {
   pollRoundIdAndPushPrice,
   scale6,
 } from './test-lib/priceFeed-lib.js';
+import {
+  retryUntilCondition,
+  waitUntilOfferResult,
+} from './test-lib/sync-tools.js';
+
+const ambientAuthority = {
+  query: agd.query,
+  follow: agoric.follow,
+  setTimeout,
+};
 
 const config = {
   vatNames: [
@@ -41,16 +64,80 @@ const config = {
   },
 };
 
-// Remove this one when #10296 goes in
+/**
+ * https://github.com/Agoric/agoric-sdk/pull/10074 introduced new price feeds to the system.
+ * However, `f:replace-price-feeds` does not activate oracles for future layers of the build.
+ * Meaning, proposals running after `f:replace-price-feeds` will not have  oracles that received
+ * invitationMakers for new price feeds and there will not be quotes published by new
+ * price feeds. There are conflicting work to fix this issue, see;
+ *  - https://github.com/Agoric/agoric-sdk/pull/10296
+ *  - https://github.com/Agoric/agoric-sdk/pull/10317
+ *  - https://github.com/Agoric/agoric-sdk/pull/10296#pullrequestreview-2389390624
+ *
+ * The purpose of init() is to unblock testing new price feeds from the situation above. We can remove
+ * this when it resolves.
+ *
+ * @param {Map<string,Array<{address: string; offerId: string}>>} oraclesByBrand
+ */
 const init = async oraclesByBrand => {
-  await registerOraclesForBrand('ATOM', oraclesByBrand);
-  await waitForBlock(3);
-  await registerOraclesForBrand('stATOM', oraclesByBrand);
-  await waitForBlock(3);
+  const retryOptions = {
+    log: console.log,
+    maxRetries: 5,
+    retryIntervalMs: 3000,
+  };
+
+  const atomInviteOffers = [];
+  registerOraclesForBrand('ATOM', oraclesByBrand);
+  // @ts-expect-error we expect oraclesByBrand.get('ATOM') will not return undefined
+  for (const { address, offerId } of oraclesByBrand.get('ATOM')) {
+    const offerP = waitUntilOfferResult(
+      address,
+      offerId,
+      false,
+      ambientAuthority,
+      {
+        errorMessage: `ERROR: ${address} could not accept invite, offerID: ${offerId}`,
+        ...retryOptions,
+      },
+    );
+    atomInviteOffers.push(offerP);
+  }
+  await Promise.all(atomInviteOffers);
+
+  const stAtomInviteOffers = [];
+  registerOraclesForBrand('stATOM', oraclesByBrand);
+  // @ts-expect-error we expect oraclesByBrand.get('ATOM') will not return undefined
+  for (const { address, offerId } of oraclesByBrand.get('stATOM')) {
+    const offerP = waitUntilOfferResult(
+      address,
+      offerId,
+      false,
+      ambientAuthority,
+      {
+        errorMessage: `ERROR: ${address} could not accept invite, offerID: ${offerId}`,
+        ...retryOptions,
+      },
+    );
+
+    stAtomInviteOffers.push(offerP);
+  }
+  await Promise.all(stAtomInviteOffers);
 
   await pushPrices(1, 'ATOM', oraclesByBrand, 1);
-  await waitForBlock(3);
+  // await waitForBlock(3);
+  await retryUntilCondition(
+    () => getPriceQuote('ATOM'),
+    res => res === '+1000000',
+    'ATOM quote not received',
+    { ...retryOptions, setTimeout },
+  );
   await pushPrices(1, 'stATOM', oraclesByBrand, 1);
+  await retryUntilCondition(
+    () => getPriceQuote('stATOM'),
+    res => res === '+1000000',
+    'stATOM quote not received',
+    { ...retryOptions, setTimeout },
+  );
 };
 
 /**
@@ -62,7 +149,7 @@ test.before(async t => {
   await bankSend(GOV2ADDR, '10000000uist', GOV1ADDR);
   await bankSend(GOV3ADDR, '10000000uist', GOV1ADDR);
 
-  const oraclesByBrand = generateOracleMap('f-priceFeeds', ['ATOM', 'stATOM']);
+  const oraclesByBrand = generateOracleMap('z-acc', ['ATOM', 'stATOM']);
   t.log(oraclesByBrand);
 
   await init(oraclesByBrand);

--- a/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.js
@@ -5,6 +5,29 @@ import {
   agoric as agoricAmbient,
   pushPrices,
 } from '@agoric/synthetic-chain';
+import { Fail, q } from '@endo/errors';
+import { getTranscriptItemsForVat } from './vat-helpers.js';
+
+/**
+ * By the time we push prices to the new price feed vat, the old one might receive
+ * some deliveries related to GC events. These delivery types might be; 'dropExports',
+ * 'retireExports', 'retireImports', 'bringOutYourDead'.
+ *
+ * Even though we don't expect to receive all these types of deliveries at once;
+ * choosing MAX_DELIVERIES_ALLOWED = 5 seems reasonable.
+ */
+const MAX_DELIVERIES_ALLOWED = 5;
+
+export const scale6 = x => BigInt(x * 1000000);
+
+/**
+ * @typedef {Record<
+ *   string,
+ *   Record<string, number>
+ * >} SnapshotItem
+ *
+ * @typedef {Record<string, SnapshotItem>} Snapshots
+ */
 
 /**
  *  Import from synthetic-chain once it is updated
@@ -37,7 +60,7 @@ export const getRoundId = async (price, io = {}) => {
     io;
   const path = `:${prefix}priceFeed.${price}-USD_price_feed.latestRound`;
   const round = await agoric.follow('-lF', path);
-  return parseInt(round.roundId);
+  return parseInt(round.roundId, 10);
 };
 
 /**
@@ -53,4 +76,68 @@ export const pollRoundIdAndPushPrice = async (
 ) => {
   const roundId = await getRoundId(brandIn);
   await pushPrices(price, brandIn, oraclesByBrand, roundId + 1);
+};
+
+/**
+ * @param {SnapshotItem} snapShotItem
+ */
+export const getQuiescentVats = snapShotItem => {
+  const quiescentVats = {};
+  [...Object.values(snapShotItem)].forEach(vats => {
+    const keyOne = Object.keys(vats)[0];
+    const keyTwo = Object.keys(vats)[1];
+
+    return parseInt(keyOne.substring(1), 10) > parseInt(keyTwo.substring(1), 10)
+      ? (quiescentVats[keyTwo] = vats[keyTwo])
+      : (quiescentVats[keyOne] = vats[keyOne]);
+  });
+
+  return quiescentVats;
+};
+
+/**
+ *
+ * @param {Snapshots} snapshots
+ * @param {{ getTranscriptItems?: () => Array}} io
+ */
+export const ensureGCDeliveryOnly = (snapshots, io = {}) => {
+  const { getTranscriptItems = getTranscriptItemsForVat } = io;
+
+  const { after, before } = snapshots;
+  const quiescentVatsBefore = getQuiescentVats(before);
+  const quiescentVatsAfter = getQuiescentVats(after);
+
+  console.dir(quiescentVatsBefore, { depth: null });
+  console.dir(quiescentVatsAfter, { depth: null });
+
+  [...Object.entries(quiescentVatsBefore)].forEach(([vatId, position]) => {
+    const afterPosition = quiescentVatsAfter[vatId];
+    const messageDiff = afterPosition - position;
+    console.log(vatId, messageDiff);
+
+    if (messageDiff > MAX_DELIVERIES_ALLOWED)
+      Fail`${q(messageDiff)} deliveries is greater than maximum allowed: ${q(MAX_DELIVERIES_ALLOWED)}`;
+    else if (messageDiff === 0) return;
+
+    const transcripts = getTranscriptItems(vatId, messageDiff);
+    console.log('TRANSCRIPTS', transcripts);
+
+    transcripts.forEach(({ item }) => {
+      const deliveryType = JSON.parse(item).d[0];
+      console.log('DELIVERY TYPE', deliveryType);
+      if (deliveryType === 'notify' || deliveryType === 'message')
+        Fail`DeliveryType ${q(deliveryType)} is not GC delivery`;
+    });
+  });
+};
+
+/**
+ * @param {number} managerIndex
+ */
+export const getQuoteFromVault = async managerIndex => {
+  const res = await agoricAmbient.follow(
+    '-lF',
+    `:published.vaultFactory.managers.manager${managerIndex}.quotes`,
+  );
+  return res.quoteAmount.value[0].amountOut.value;
 };

--- a/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.js
@@ -1,0 +1,56 @@
+import {
+  agd,
+  CHAINID,
+  VALIDATORADDR,
+  agoric as agoricAmbient,
+  pushPrices,
+} from '@agoric/synthetic-chain';
+
+/**
+ *  Import from synthetic-chain once it is updated
+ *
+ * @param {string} addr
+ * @param {string} wanted
+ * @param {string} [from]
+ */
+export const bankSend = (addr, wanted, from = VALIDATORADDR) => {
+  const chain = ['--chain-id', CHAINID];
+  const fromArg = ['--from', from];
+  const testKeyring = ['--keyring-backend', 'test'];
+  const noise = [...fromArg, ...chain, ...testKeyring, '--yes'];
+
+  return agd.tx('bank', 'send', from, addr, wanted, ...noise);
+};
+
+/**
+ * Import from synthetic-chain when https://github.com/Agoric/agoric-3-proposals/pull/183 is in
+ *
+ * @param {string} price
+ * @param {{
+ *   agoric?: { follow: () => Promise<object>};
+ *   prefix?: string
+ * }} io
+ * @returns
+ */
+export const getRoundId = async (price, io = {}) => {
+  const { agoric = { follow: agoricAmbient.follow }, prefix = 'published.' } =
+    io;
+  const path = `:${prefix}priceFeed.${price}-USD_price_feed.latestRound`;
+  const round = await agoric.follow('-lF', path);
+  return parseInt(round.roundId);
+};
+
+/**
+ *
+ * @param {string} brandIn
+ * @param {number} price
+ * @param {import('../priceFeed.test.js').OraclesByBrand} oraclesByBrand
+ */
+export const pollRoundIdAndPushPrice = async (
+  brandIn,
+  price,
+  oraclesByBrand,
+) => {
+  const roundId = await getRoundId(brandIn);
+  await pushPrices(price, brandIn, oraclesByBrand, roundId + 1);
+};

--- a/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.test.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/priceFeed-lib.test.js
@@ -1,0 +1,103 @@
+import test from 'ava';
+import '@endo/init';
+import { ensureGCDeliveryOnly } from './priceFeed-lib.js';
+
+const testConfig = {
+  before: {
+    '-scaledPriceAuthority-stATOM': { v58: 13, v74: 119 },
+    '-scaledPriceAuthority-ATOM': { v46: 77, v73: 178 },
+    '-stATOM-USD_price_feed': { v57: 40, v72: 192 },
+    '-ATOM-USD_price_feed': { v29: 100, v70: 247 },
+  },
+  after: {
+    '-scaledPriceAuthority-stATOM': { v58: 15, v74: 119 },
+    '-scaledPriceAuthority-ATOM': { v46: 79, v73: 178 },
+    '-stATOM-USD_price_feed': { v57: 42, v72: 192 },
+    '-ATOM-USD_price_feed': { v29: 102, v70: 247 },
+  },
+};
+
+const makeFakeGetTranscriptItemsForVat = (
+  deliveryType,
+  maximumAllowedDeliveries,
+) => {
+  const fakeGetTranscriptItemsForVat = (_, number) => {
+    const fakeTranscriptItems = [];
+    for (let i = 0; i < number; i += 1) {
+      const item = { d: [deliveryType] };
+      fakeTranscriptItems.push({ item: JSON.stringify(item) });
+    }
+    return fakeTranscriptItems;
+  };
+
+  const tooManyTranscriptItemsForVat = () => {
+    const fakeTranscriptItems = [];
+    for (let i = 0; i <= maximumAllowedDeliveries; i += 1) {
+      const item = { d: [deliveryType] };
+      fakeTranscriptItems.push({ item: JSON.stringify(item) });
+    }
+    return fakeTranscriptItems;
+  };
+
+  return { fakeGetTranscriptItemsForVat, tooManyTranscriptItemsForVat };
+};
+
+test('should not throw', t => {
+  const { fakeGetTranscriptItemsForVat } =
+    makeFakeGetTranscriptItemsForVat('dropExports');
+
+  t.notThrows(() =>
+    ensureGCDeliveryOnly(testConfig, {
+      getTranscriptItems: fakeGetTranscriptItemsForVat,
+    }),
+  );
+});
+
+test('should throw for "notify"', t => {
+  const { fakeGetTranscriptItemsForVat } =
+    makeFakeGetTranscriptItemsForVat('notify');
+
+  t.throws(
+    () =>
+      ensureGCDeliveryOnly(testConfig, {
+        getTranscriptItems: fakeGetTranscriptItemsForVat,
+      }),
+    { message: 'DeliveryType "notify" is not GC delivery' },
+  );
+});
+
+test('should throw for "message"', t => {
+  const { fakeGetTranscriptItemsForVat } =
+    makeFakeGetTranscriptItemsForVat('message');
+
+  t.throws(
+    () =>
+      ensureGCDeliveryOnly(testConfig, {
+        getTranscriptItems: fakeGetTranscriptItemsForVat,
+      }),
+    { message: 'DeliveryType "message" is not GC delivery' },
+  );
+});
+
+test('should throw too many deliveries', t => {
+  const { fakeGetTranscriptItemsForVat } = makeFakeGetTranscriptItemsForVat(
+    'dropExports',
+    5,
+  );
+
+  const config = {
+    ...testConfig,
+    after: {
+      ...testConfig.after,
+      '-scaledPriceAuthority-stATOM': { v58: 20, v74: 119 },
+    },
+  };
+
+  t.throws(
+    () =>
+      ensureGCDeliveryOnly(config, {
+        getTranscriptItems: fakeGetTranscriptItemsForVat,
+      }),
+    { message: '7 deliveries is greater than maximum allowed: 5' },
+  );
+});

--- a/a3p-integration/proposals/z:acceptance/test-lib/vat-helpers.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/vat-helpers.js
@@ -8,9 +8,12 @@ import { HOME, dbTool } from '@agoric/synthetic-chain';
 const swingstorePath = '~/.agoric/data/agoric/swingstore.sqlite';
 
 /**
+ * Initially from https://github.com/Agoric/agoric-3-proposals/blob/93bb953db209433499db08ae563942d1bf7eeb46/proposals/76%3Avaults-auctions/vatDetails.js#L36
+ * but with small modifications
+ *
  * @param {import('better-sqlite3').Database} db
  */
-export const makeSwingstore = db => {
+const makeSwingstore = db => {
   const sql = dbTool(db);
 
   /** @param {string} key */
@@ -66,23 +69,6 @@ const initSwingstore = () => {
 };
 
 /**
- * @param {string} vatName
- */
-export const getVatsWithSameName = async vatName => {
-  const kStore = initSwingstore();
-
-  const vatIDs = kStore.findVatsExact(vatName);
-  const vats = vatIDs.map(id => {
-    const vatLookup = kStore.lookupVat(id);
-    return {
-      options: vatLookup.options(),
-      currentSpan: vatLookup.currentSpan(),
-    };
-  });
-  return vats;
-};
-
-/**
  *
  * @param {string} vatId
  * @param {number} n
@@ -114,7 +100,3 @@ export const snapshotVat = vatName => {
 
   return snapshots;
 };
-
-export const swingStore = makeSwingstore(
-  dbOpenAmbient(swingstorePath.replace(/^~/, HOME), { readonly: true }),
-);

--- a/a3p-integration/proposals/z:acceptance/test-lib/vat-helpers.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/vat-helpers.js
@@ -1,0 +1,102 @@
+import dbOpenAmbient from 'better-sqlite3';
+import { HOME, dbTool } from '@agoric/synthetic-chain';
+
+/**
+ * @file look up vat incarnation from kernel DB
+ * @see {getIncarnation}
+ */
+
+const swingstorePath = '~/.agoric/data/agoric/swingstore.sqlite';
+
+/**
+ * @param {import('better-sqlite3').Database} db
+ */
+export const makeSwingstore = db => {
+  const sql = dbTool(db);
+
+  /** @param {string} key */
+  // @ts-expect-error sqlite typedefs
+  const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
+  /** @param {string} key */
+  const kvGetJSON = key => JSON.parse(kvGet(key));
+
+  /** @param {string} vatID */
+  const lookupVat = vatID => {
+    return Object.freeze({
+      source: () => kvGetJSON(`${vatID}.source`),
+      options: () => kvGetJSON(`${vatID}.options`),
+      currentSpan: () =>
+        sql.get`select * from transcriptSpans where isCurrent = 1 and vatID = ${vatID}`,
+    });
+  };
+
+  return Object.freeze({
+    /** @param {string} vatName */
+    findVat: vatName => {
+      /** @type {string[]} */
+      const dynamicIDs = kvGetJSON('vat.dynamicIDs');
+      const targetVat = dynamicIDs.find(vatID =>
+        lookupVat(vatID).options().name.includes(vatName),
+      );
+      if (!targetVat) throw Error(`vat not found: ${vatName}`);
+      return targetVat;
+    },
+    /** @param {string} string a substring to search for within the vat name. */
+    findVatsExact: string => {
+      /** @type {string[]} */
+      const dynamicIDs = kvGetJSON('vat.dynamicIDs');
+      return dynamicIDs.filter(vatID =>
+        lookupVat(vatID).options().name.endsWith(string),
+      );
+    },
+    findVatsAll: string => {
+      /** @type {string[]} */
+      const dynamicIDs = kvGetJSON('vat.dynamicIDs');
+      return dynamicIDs.filter(vatID =>
+        lookupVat(vatID).options().name.includes(string),
+      );
+    },
+    lookupVat,
+    kvGetJSON,
+    sql,
+    db,
+  });
+};
+
+/**
+ * @param {string} vatName
+ */
+export const getVatsWithSameName = async vatName => {
+  const fullPath = swingstorePath.replace(/^~/, HOME);
+  const kStore = makeSwingstore(dbOpenAmbient(fullPath, { readonly: true }));
+
+  const vatIDs = kStore.findVatsExact(vatName);
+  const vats = vatIDs.map(id => {
+    const vatLookup = kStore.lookupVat(id);
+    return {
+      options: vatLookup.options(),
+      currentSpan: vatLookup.currentSpan(),
+    };
+  });
+  return vats;
+};
+
+export const getTranscriptItemsForVat = (vatId, n = 10) => {
+  const fullPath = swingstorePath.replace(/^~/, HOME);
+  const { sql, db } = makeSwingstore(
+    dbOpenAmbient(fullPath, { readonly: true }),
+  );
+
+  // const items = sql.get`select * from transcriptItems where vatId = ${vatId} order by position desc limit ${n}`;
+  const items = db
+    .prepare(
+      'select * from transcriptItems where vatId = ? order by position desc limit ?',
+    )
+    .all(vatId, n);
+  // console.log(items);
+  return items;
+};
+
+export const swingStore = makeSwingstore(
+  dbOpenAmbient(swingstorePath.replace(/^~/, HOME), { readonly: true }),
+);

--- a/a3p-integration/proposals/z:acceptance/test.sh
+++ b/a3p-integration/proposals/z:acceptance/test.sh
@@ -26,5 +26,8 @@ echo ACCEPTANCE TESTING state sync
 echo ACCEPTANCE TESTING wallet
 yarn ava wallet.test.js
 
+echo ACCEPTANCE TESTING replaced price feeds
+yarn ava priceFeed.test.js
+
 echo ACCEPTANCE TESTING vaults
 yarn ava vaults.test.js

--- a/a3p-integration/proposals/z:acceptance/vaults.test.js
+++ b/a3p-integration/proposals/z:acceptance/vaults.test.js
@@ -14,7 +14,6 @@ import {
   ATOM_DENOM,
   USER1ADDR,
   waitForBlock,
-  registerOraclesForBrand,
   generateOracleMap,
 } from '@agoric/synthetic-chain';
 import { getBalances, agopsVaults } from './test-lib/utils.js';
@@ -30,13 +29,12 @@ test.before(async t => {
     retryIntervalMs: 5000, // in ms
   };
   t.context = {
-    roundId: 1,
+    roundId: 3,
     retryOpts: {
       pushPriceRetryOpts,
     },
   };
   const oraclesByBrand = generateOracleMap('z-acc', ['ATOM']);
-  await registerOraclesForBrand('ATOM', oraclesByBrand);
 
   const price = 15.2;
   // @ts-expect-error   t.context is fine

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -784,6 +784,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"better-sqlite3@npm:11.5.0":
+  version: 11.5.0
+  resolution: "better-sqlite3@npm:11.5.0"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.1"
+  checksum: 10c0/c24200972e11f6f99c4e6538122bd7ec8b31b92b2fa095f4b595cc39fedf924cb0a93fd326f0900415eccdf634367f7bba2ba4eaa4d164edd7352f4cfaaaec51
+  languageName: node
+  linkType: hard
+
 "better-sqlite3@npm:^9.6.0":
   version: 9.6.0
   resolution: "better-sqlite3@npm:9.6.0"
@@ -2517,6 +2528,7 @@ __metadata:
     "@endo/far": "npm:^1.1.5"
     "@endo/init": "npm:^1.1.4"
     ava: "npm:^6.1.2"
+    better-sqlite3: "npm:11.5.0"
     execa: "npm:^9.3.1"
     tsx: "npm:^4.17.0"
     typescript: "npm:^5.5.4"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/BytePitchPartnerEng/issues/25
refs: https://github.com/Agoric/agoric-sdk/issues/9928

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
#10074 replaced existing `priceFeeds` and `scaledPriceAuthorities` with new ones that should be more efficient in terms of space usage. However, terminating those old vats is a problem that hasn't been solved as described in #9483. So it is important to make sure those old vats are actually quiescent. We also need to make sure we are able to produce quotes successfully. In this PR we are addressing these concerns.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
None.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Regarding observing vat details there are 2 assumptions we are relying on;
* dynamic vat ids are created incrementally (newly created vats have a higher vat id)
* number of deliveries to a vat caused by a gc sweep do not exceed 5

#9928 talks about making sure auctions receive quotes. That is no tested here due to the high fidelity of testing auctions. The auctions features are tested #10229 so I believe there will be comprehensive coverage when it is merged.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
None.

### Help from reviewers
#10074 introduced new price feeds to the system. However, `f:replace-price-feeds` does not activate oracles for future layers of the build. Meaning, proposals running after `f:replace-price-feeds` will not have  oracles that received  invitationMakers for new price feeds and there will not be quotes published by new price feeds. There are conflicting work to fix this issue, see; 
* https://github.com/Agoric/agoric-sdk/pull/10296
* https://github.com/Agoric/agoric-sdk/pull/10317
* https://github.com/Agoric/agoric-sdk/pull/10296#pullrequestreview-2389390624 
  
As a work around I've implemented an `init` method that runs during `test.before` to set the stage before we start testing new price feeds. I could use some guidance from you guys how to proceed from here. One option I can think of is to have `init` work conditionally.
* If oracles are registered to new price feeds, do not register them
* If they did not, register them


